### PR TITLE
fix: Do not use down arrow key to navigate to the next item in tag seection with item test

### DIFF
--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2168,7 +2168,6 @@ describe('NgSelectComponent', () => {
             tickAndDetectChanges(fixture);
             fixture.componentInstance.select.filter('Vil');
             tickAndDetectChanges(fixture);
-            triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.ArrowDown);
             triggerKeyDownEvent(getNgSelectElement(fixture), KeyCode.Enter);
             expect(fixture.componentInstance.selectedCity.name).toBe('Vil');
         }));


### PR DESCRIPTION
This is no longer necessary because the add tag is the first item