### PR TITLE
CTAPP-2174: Select the tag on blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,4 +298,4 @@ It makes the following changes compared with upstream:
   * The search input is not cleared when closing the dropdown or clicking outside of the input.
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
-  * Additional option `[selectOnBlur]` to select the marked item or the custom tag on blur
+  * Additional option `[selectTagOnBlur]` to select the custom tag (if any) on blur

--- a/README.md
+++ b/README.md
@@ -298,3 +298,4 @@ It makes the following changes compared with upstream:
   * The search input is not cleared when closing the dropdown or clicking outside of the input.
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
+  * Additional option `[selectOnBlur]` to select the marked item or the custom tag on blur

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -71,7 +71,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() inputAttrs: { [key: string]: string } = {};
     @Input() tabIndex: number;
     @Input() alwaysShowAddTag = false;
-    @Input() selectOnBlur = true;
+    @Input() selectTagOnBlur = true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
@@ -376,15 +376,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         this._cd.markForCheck();
     }
 
-    selectItem(item: NgOption) {
-        if (!item || item.disabled || this.disabled) {
-            return;
-        }
-
-        this.select(item);
-        this._onSelectionChanged();
-    }
-
     toggleItem(item: NgOption) {
         if (!item || item.disabled || this.disabled) {
             return;
@@ -535,12 +526,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     onInputBlur($event) {
-        if (this.selectOnBlur) {
-            if (this.itemsList.markedItem) {
-                this.selectItem(this.itemsList.markedItem);
-            } else if (this.showAddTag) {
-                this.selectTag();
-            }
+        if (this.showAddTag && this.selectTagOnBlur) {
+            this.selectTag();
         }
 
         this.element.classList.remove('ng-select-focused');

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -40,7 +40,6 @@ export type GroupValueFn = (key: string | object, children: any[]) => string | o
     }
 })
 export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, ControlValueAccessor {
-
     @Input() bindLabel: string;
     @Input() bindValue: string;
     @Input() markFirst = true;
@@ -72,6 +71,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() inputAttrs: { [key: string]: string } = {};
     @Input() tabIndex: number;
     @Input() alwaysShowAddTag = false;
+    @Input() selectOnBlur = true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
@@ -376,6 +376,15 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         this._cd.markForCheck();
     }
 
+    selectItem(item: NgOption) {
+        if (!item || item.disabled || this.disabled) {
+            return;
+        }
+
+        this.select(item);
+        this._onSelectionChanged();
+    }
+
     toggleItem(item: NgOption) {
         if (!item || item.disabled || this.disabled) {
             return;
@@ -526,11 +535,21 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     onInputBlur($event) {
+        if (this.selectOnBlur) {
+            if (this.itemsList.markedItem) {
+                this.selectItem(this.itemsList.markedItem);
+            } else if (this.showAddTag) {
+                this.selectTag();
+            }
+        }
+
         this.element.classList.remove('ng-select-focused');
         this.blurEvent.emit($event);
+
         if (!this.isOpen && !this.disabled) {
             this._onTouched();
         }
+
         this.focused = false;
     }
 


### PR DESCRIPTION
This is the simplest solution I could come up with to prevent users from losing their inputs when they have not explicitly selected a dropdown option. It would be possible to continuously save user input, but this would require significant changes to `ng-select`.