### PR TITLE
CTAPP-2195: Keyboard up/down arrow keys cause incorrect scrolling behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [3.0.13](https://github.com/ct-cue/ng-select/compare/v3.0.12...v3.0.13) (2019-10-28)
 
+* Additional option `[selectTagOnBlur]` to select the custom tag (if any) when the input is blurred
 
 
 ### [3.0.12](https://github.com/ct-cue/ng-select/compare/v3.0.11...v3.0.12) (2019-10-25)

--- a/README.md
+++ b/README.md
@@ -299,4 +299,3 @@ It makes the following changes compared with upstream:
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
   * Additional option `[selectTagOnBlur]` to select the custom tag (if any) on blur
-  * Additional option `[clearSearchOnBlur]` to clear the input on blur

--- a/README.md
+++ b/README.md
@@ -299,3 +299,4 @@ It makes the following changes compared with upstream:
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
   * Additional option `[selectTagOnBlur]` to select the custom tag (if any) on blur
+  * Additional option `[clearSearchOnBlur]` to clear the input on blur

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -165,7 +165,9 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
+
         let scrollTo;
+
         if (this.virtualScroll) {
             const itemHeight = this._panelService.dimensions.itemHeight;
             scrollTo = this._panelService.getScrollTo(index * itemHeight, itemHeight, this._lastScrollPosition);
@@ -260,9 +262,6 @@ export class NgDropdownPanelComponent implements OnInit, OnChanges, OnDestroy {
 
     private _updateItems(firstChange: boolean) {
         this.update.emit(this.items);
-        if (firstChange === false) {
-            return;
-        }
 
         this._zone.runOutsideAngular(() => {
             Promise.resolve().then(() => {

--- a/src/ng-select/lib/ng-dropdown-panel.service.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.service.ts
@@ -63,18 +63,27 @@ export class NgDropdownPanelService {
 
     getScrollTo(itemTop: number, itemHeight: number, lastScroll: number) {
         const { panelHeight } = this.dimensions;
-        const itemBottom = itemTop + itemHeight;
-        const top = lastScroll;
-        const bottom = top + panelHeight;
 
+        const itemBottom = itemTop + itemHeight;
+
+        const viewportTop = lastScroll;
+        const viewportBottom = viewportTop + panelHeight;
+
+        /**
+         * Return if the bottom of the item is visible
+         * and the scroll position has not changed
+         */
         if (panelHeight >= itemBottom && lastScroll === itemTop) {
             return null;
         }
 
-        if (itemBottom > bottom) {
-            return top + itemBottom - bottom;
-        } else if (itemTop <= top) {
-            return itemTop;
+        // Scroll down if the bottom of the item is outside the viewport
+        if (itemBottom > viewportBottom) {
+            return viewportTop + (itemBottom - viewportBottom);
+
+        // Scroll up if the top of the item is outside the viewport
+        } else if (itemTop <= viewportTop) {
+            return itemTop; // This works well for obvious reasons
         }
 
         return null;

--- a/src/ng-select/lib/ng-dropdown-panel.service.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.service.ts
@@ -83,7 +83,7 @@ export class NgDropdownPanelService {
 
         // Scroll up if the top of the item is outside the viewport
         } else if (itemTop <= viewportTop) {
-            return itemTop; // This works well for obvious reasons
+            return itemTop;
         }
 
         return null;

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -14,8 +14,6 @@ import { NgFooterTemplateDirective, NgHeaderTemplateDirective, NgLabelTemplateDi
 import { SelectionModelFactory } from './selection-model';
 import { isDefined, isFunction, isObject, isPromise } from './value-utils';
 
-
-
 export const SELECTION_MODEL_FACTORY = new InjectionToken<SelectionModelFactory>('ng-select-selection-model');
 export type DropdownPosition = 'bottom' | 'top' | 'auto';
 export type AddTagFn = ((term: string) => any | Promise<any>);
@@ -72,6 +70,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() tabIndex: number;
     @Input() alwaysShowAddTag = false;
     @Input() selectTagOnBlur = true;
+    @Input() clearSearchOnBlur = true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
@@ -356,9 +355,11 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
         if (!this._isTypeahead && !this.addTag && this.itemsList.noItemsToSelect) {
             return;
         }
+
         this.isOpen = true;
         this.itemsList.markSelectedOrDefault(this.markFirst && !this.showAddTag);
         this.openEvent.emit();
+
         if (!this.searchTerm) {
             this.focus();
         }
@@ -528,6 +529,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     onInputBlur($event) {
         if (this.showAddTag && this.selectTagOnBlur) {
             this.selectTag();
+        }
+
+        if (this.clearSearchOnBlur) {
+            this._clearSearch();
         }
 
         this.element.classList.remove('ng-select-focused');

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -70,7 +70,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() tabIndex: number;
     @Input() alwaysShowAddTag = false;
     @Input() selectTagOnBlur = true;
-    @Input() clearSearchOnBlur = true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
@@ -529,10 +528,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     onInputBlur($event) {
         if (this.showAddTag && this.selectTagOnBlur) {
             this.selectTag();
-        }
-
-        if (this.clearSearchOnBlur) {
-            this._clearSearch();
         }
 
         this.element.classList.remove('ng-select-focused');


### PR DESCRIPTION
The issues where caused by `panelHeight` being set to `0` in the `NgDropdownPanelService` because it was only calculated the first time items were set. This would be an empty list (with a height of `0`) in case of the advanced text search. It is now recalculated on every items change.