### PR TITLE
CTAPP-2201+2200: Focus open conflict and input not saved when it matches an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,15 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [3.0.14](https://github.com/ct-cue/ng-select/compare/v3.0.13...v3.0.14) (2019-10-28)
 
-
+* Fixes issue that prevented the dropdown panel height from being calculated once items had been fetched
 
 ### [3.0.13](https://github.com/ct-cue/ng-select/compare/v3.0.12...v3.0.13) (2019-10-28)
 
 * Additional option `[selectTagOnBlur]` to select the custom tag (if any) when the input is blurred
 
-
 ### [3.0.12](https://github.com/ct-cue/ng-select/compare/v3.0.11...v3.0.12) (2019-10-25)
 
-
+* Change the repository path to `@ctcue/ng-select`
 
 ### [3.0.11](https://github.com/ct-cue/ng-select/compare/v3.0.10...v3.0.11) (2019-10-25)
 

--- a/README.md
+++ b/README.md
@@ -298,4 +298,4 @@ It makes the following changes compared with upstream:
   * The search input is not cleared when closing the dropdown or clicking outside of the input.
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
-  * Additional option `[selectTagOnBlur]` to select the custom tag (if any) on blur
+  * Additional option `[selectOnBlur]` to select the input (if any) on blur

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -282,6 +282,15 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
 
         if (!this.focused) {
             this.focus();
+
+            /**
+             * Return if focussing already causes the dropdown to open
+             * to prevent `toggle()` from immediately closing the dropdown
+             * if the `ng-select` is not searchable
+             */
+            if (this.openOnFocus) {
+                return;
+            }
         }
 
         if (this.searchable) {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -535,8 +535,8 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     onInputBlur($event) {
-        if (this.searchTerm && this.searchTerm.length && this.addTag && this.selectOnBlur) {
-            this.selectTag();
+        if (this.selectOnBlur && this.searchTerm && this.searchTerm.length) {
+            this._selectInput();
         }
 
         this.element.classList.remove('ng-select-focused');
@@ -767,6 +767,23 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             return;
         }
         this.dropdownPanel.scrollToTag();
+    }
+
+    private _selectInput() {
+        const term = this.searchTerm.toLowerCase();
+
+        // Select the first item that exactly matches the input
+        for (const item of this.itemsList.filteredItems) {
+            if (item.label.toLowerCase() === term) {
+                this.toggleItem(item);
+                return;
+            }
+        }
+
+        // Select the tag if no item exactly matched the input
+        if (this.addTag) {
+            this.selectTag();
+        }
     }
 
     private _onSelectionChanged() {

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -69,7 +69,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() inputAttrs: { [key: string]: string } = {};
     @Input() tabIndex: number;
     @Input() alwaysShowAddTag = false;
-    @Input() selectTagOnBlur = true;
+    @Input() selectOnBlur = true;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;
@@ -535,7 +535,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     onInputBlur($event) {
-        if (this.showAddTag && this.selectTagOnBlur) {
+        if (this.searchTerm && this.searchTerm.length && this.addTag && this.selectOnBlur) {
             this.selectTag();
         }
 

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -535,7 +535,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     onInputBlur($event) {
-        if (this.selectOnBlur && this.searchTerm && this.searchTerm.length) {
+        if (this.selectOnBlur) {
             this._selectInput();
         }
 
@@ -770,6 +770,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     private _selectInput() {
+        if (!this.searchTerm || !this.searchTerm.length) {
+            return;
+        }
+
         const term = this.searchTerm.toLowerCase();
 
         // Select the first item that exactly matches the input


### PR DESCRIPTION
- Prevent the dropdown menu from closing immediately when it is being opened because of focus. This happened because mouse clicks toggle the open/closed state for non-searchable `ng-select`.
- Select the first item that exactly matches the input on blur. Previously, only input that did not match any item was selected because we used `this.showAddTag`.