### PR TITLE
Only prevent-default the escape keydown event when the menu is open

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -248,8 +248,10 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
                     this._handleTab($event);
                     break;
                 case KeyCode.Esc:
-                    this.close();
-                    $event.preventDefault();
+                    if (this.isOpen) {
+                        this.close();
+                        $event.preventDefault();
+                    }
                     break;
                 case KeyCode.Backspace:
                     this._handleBackspace();


### PR DESCRIPTION
This stops the event from being prevent default-ed when the menu is already closed, allowing the second escape keypress to close a parent component