### PR TITLE
CTAPP-2277: Do not select on blur by default

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -69,7 +69,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() inputAttrs: { [key: string]: string } = {};
     @Input() tabIndex: number;
     @Input() alwaysShowAddTag = false;
-    @Input() selectOnBlur = true;
+    @Input() selectOnBlur = false;
 
     @Input() @HostBinding('class.ng-select-typeahead') typeahead: Subject<string>;
     @Input() @HostBinding('class.ng-select-multiple') multiple = false;


### PR DESCRIPTION
Change the default of `selectOnBlur` so we can opt-in in ctReach instead of opting out.