### PR TITLE
CTAPP-2455: Retain search input/suggestions on select by default for multi-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ It makes the following changes compared with upstream:
   * The custom `[addTag]` is visible while loading (if enabled).
   * The loading text is hidden while the custom `[addTag]` is visible.
   * The search input is not cleared when closing the dropdown or clicking outside of the input.
+  * The search input is not cleared when selecting an item (this behaviour can be disabled).
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
   * Additional option `[selectOnBlur]` to select the input (if any) on blur

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ It makes the following changes compared with upstream:
   * The custom `[addTag]` is visible while loading (if enabled).
   * The loading text is hidden while the custom `[addTag]` is visible.
   * The search input is not cleared when closing the dropdown or clicking outside of the input.
-  * The search input is not cleared when selecting an item (this behaviour can be disabled).
+  * The search input is not cleared when selecting an item if only a single item can be selected (by default).
   * The text cursor is always placed after the selected values(s).
   * Additional option `[openOnFocus]` to open the dropdown when the input is focused
   * Additional option `[selectOnBlur]` to select the input (if any) on blur

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -2652,29 +2652,6 @@ describe('NgSelectComponent', () => {
                 expect(fixture.componentInstance.select.searchTerm).toBeNull();
             }));
 
-            it('should not clear search term by default when closeOnSelect is false ', fakeAsync(() => {
-                const fixture = createTestingModule(
-                    NgSelectTestCmp,
-                    `<ng-select [items]="cities"
-                        [typeahead]="filter"
-                        bindLabel="name"
-                        [hideSelected]="hideSelected"
-                        [closeOnSelect]="false"
-                        [(ngModel)]="selectedCity">
-                    </ng-select>`);
-
-                expect(fixture.componentInstance.select.clearSearchOnAdd).toBeFalsy();
-
-                fixture.componentInstance.filter.subscribe();
-                fixture.componentInstance.select.filter('new');
-                fixture.componentInstance.cities = [{ id: 4, name: 'New York' }];
-                tickAndDetectChanges(fixture);
-
-                fixture.componentInstance.select.select(fixture.componentInstance.select.viewPortItems[0]);
-                expect(fixture.componentInstance.select.itemsList.filteredItems.length).toBe(1);
-                expect(fixture.componentInstance.select.searchTerm).toBe('new');
-            }));
-
             it('should not clear search term when clearSearchOnAdd is false', fakeAsync(() => {
                 const fixture = createTestingModule(
                     NgSelectTestCmp,
@@ -3063,6 +3040,7 @@ describe('NgSelectComponent', () => {
                             bindLabel="name"
                             [multiple]="true"
                             [disabled]="disabled"
+                            [openOnFocus]="false"
                             [(ngModel)]="selectedCities">
                     </ng-select>`);
 

--- a/src/ng-select/lib/ng-select.component.spec.ts
+++ b/src/ng-select/lib/ng-select.component.spec.ts
@@ -1909,7 +1909,8 @@ describe('NgSelectComponent', () => {
                     bindLabel="name"
                     placeholder="select value"
                     [(ngModel)]="selectedCities"
-                    [multiple]="true">
+                    [multiple]="true"
+                    [openOnFocus]="false">
                 </ng-select>`);
         });
 
@@ -1954,17 +1955,6 @@ describe('NgSelectComponent', () => {
                 selectOption(fixture, KeyCode.ArrowDown, 1);
                 selectOption(fixture, KeyCode.ArrowDown, 1);
                 tickAndDetectChanges(fixture);
-                expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(2);
-            }));
-
-            it('should not open dropdown when maximum of items is reached', fakeAsync(() => {
-                const clickArrow = () => arrowIcon.triggerEventHandler('click', {});
-                selectOption(fixture, KeyCode.ArrowDown, 0);
-                selectOption(fixture, KeyCode.ArrowDown, 1);
-                tickAndDetectChanges(fixture);
-                clickArrow();
-                tickAndDetectChanges(fixture);
-                expect(fixture.componentInstance.select.isOpen).toBe(false);
                 expect((<NgOption[]>fixture.componentInstance.select.selectedItems).length).toBe(2);
             }));
         });
@@ -2474,7 +2464,8 @@ describe('NgSelectComponent', () => {
                 `<ng-select [items]="cities"
                     bindLabel="name"
                     [(ngModel)]="selectedCity"
-                    [multiple]="true">
+                    [multiple]="true"
+                    [clearSearchOnAdd]="true">
                 </ng-select>`);
 
             tickAndDetectChanges(fixture);
@@ -2963,7 +2954,8 @@ describe('NgSelectComponent', () => {
                             autofocus
                             bindLabel="name"
                             [multiple]="true"
-                            [(ngModel)]="selectedCities">
+                            [(ngModel)]="selectedCities"
+                            [openOnFocus]="false">
                 </ng-select>`);
             const select = fixture.componentInstance.select;
             const focus = spyOn(select, 'focus');

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -95,7 +95,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     }
 
     @Input()
-    get clearSearchOnAdd() { return isDefined(this._clearSearchOnAdd) ? this._clearSearchOnAdd : this.closeOnSelect; };
+    get clearSearchOnAdd() { return isDefined(this._clearSearchOnAdd) ? this._clearSearchOnAdd : !this.multiple; };
     set clearSearchOnAdd(value) {
         this._clearSearchOnAdd = value;
     };
@@ -148,7 +148,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     private _manualOpen: boolean;
     private _pressedKeys: string[] = [];
     private _compareWith: CompareWithFn;
-    private _clearSearchOnAdd = false;
+    private _clearSearchOnAdd: boolean;
 
     private readonly _destroy$ = new Subject<void>();
     private readonly _keyPress$ = new Subject<string>();

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -148,7 +148,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     private _manualOpen: boolean;
     private _pressedKeys: string[] = [];
     private _compareWith: CompareWithFn;
-    private _clearSearchOnAdd: boolean;
+    private _clearSearchOnAdd = false;
 
     private readonly _destroy$ = new Subject<void>();
     private readonly _keyPress$ = new Subject<string>();

--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -50,7 +50,6 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     @Input() dropdownPosition: DropdownPosition = 'auto';
     @Input() appendTo: string;
     @Input() loading = false;
-    @Input() closeOnSelect = true;
     @Input() hideSelected = false;
     @Input() selectOnTab = false;
     @Input() openOnEnter: boolean;
@@ -99,6 +98,12 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     set clearSearchOnAdd(value) {
         this._clearSearchOnAdd = value;
     };
+
+    @Input()
+    get closeOnSelect() { return isDefined(this._closeOnSelect) ? this._closeOnSelect : !this.multiple; }
+    set closeOnSelect(value) {
+        this._closeOnSelect = value;
+    }
 
     // output events
     @Output('blur') blurEvent = new EventEmitter();
@@ -149,6 +154,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
     private _pressedKeys: string[] = [];
     private _compareWith: CompareWithFn;
     private _clearSearchOnAdd: boolean;
+    private _closeOnSelect: boolean;
 
     private readonly _destroy$ = new Subject<void>();
     private readonly _keyPress$ = new Subject<string>();


### PR DESCRIPTION
- Additionally configure test components so that tests pass and remove tests that are no longer applicable because we changed `ng-select` logic