### PR TITLE
CTAPP-3268: Do not reopen dropdown when restoring window/tab focus

### DIFF
--- a/src/ng-select/lib/ng-select.component.ts
+++ b/src/ng-select/lib/ng-select.component.ts
@@ -577,7 +577,13 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
             this._onTouched();
         }
 
-        this.focused = false;
+        // Only unset `focused` if another element is receiving focus.
+        // This is to prevent `focused` from being unset
+        // when the window/tab loses focus and the dropdown
+        // from being re-opened when focus on the window/tab is restored
+        if ($event.relatedTarget) {
+            this.focused = false;
+        }
     }
 
     onItemHover(item: NgOption) {


### PR DESCRIPTION
This is to fix https://ct-cue.atlassian.net/browse/CTAPP-3268. That bug happens because the `ng-select` input loses focus when the browser window/tab loses focus and focus on the `ng-select` input is restored when the browser window/tab gains focus again, which causes the dropdown to reopen if `[openOnFocus]` is set.

To test within our application:

- `cd <REPOSITORIES>/ng-select`
- `yarn run build`
- `cd <REPOSITORIES>/ctReach/app/client/node_modules/app/client/node_modules/@ct-cue`
- `rm -rf ng-select; mkdir ng-select; cp -r <REPOSITORIES>/ng-select/dist/ng-select/* ng-select/`

Please check this for side effects.